### PR TITLE
Compat fix for Apple II DeskTop

### DIFF
--- a/src/apple2/pt3_player.inc
+++ b/src/apple2/pt3_player.inc
@@ -279,23 +279,18 @@ new_song:
 	bne cmd_line_play
 	jmp do_quit_player	; If path is / ($AF) then the song has played, so quit
 cmd_line_play:
-    clc               ; play the command line file
-    adc #1
-    tay
-    adc PATHNAME
-    sta PATHNAME
-    tax
-    lda #$AF
-    sta main::str_path
-    lda #1
-    sta NUM_PT3_FILES
-    inx
-:    
-    lda main::str_path,y
-    sta PATHNAME,x
-    dex
-    dey
-    bpl :-
+	tax			; play the command line file
+	lda #$AF		; set path to / ($AF) so quits after playing
+	sta main::str_path
+	lda #1
+	sta NUM_PT3_FILES
+
+	stx PATHNAME
+:
+	lda main::str_path,x	; copy path from command line to our path buffer
+	sta PATHNAME,x
+	dex
+	bne :-
 
 	lda #<(PATHNAME+1)
 	sta INL


### PR DESCRIPTION
a2stuff/a2d@eafc037 corrected the "interpreter protocol" usage by A2D when launching external commands and passing filenames, correcting a misunderstanding. That broke launching PT3 files using this system file.

This change simplifies the launch code - the passed path can be used directly without needing to compose it with any other path.